### PR TITLE
Ignore files inside `.vscode-test`

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# VSCode test files
+.vscode-test


### PR DESCRIPTION
**Reasons for making this change:**

[vscode-test](https://github.com/microsoft/vscode-test) is a testing framework for vscode extensions. Inside the `vscode-test` folder are stored one or more versions of vscode, which are used for testing a vscode extension.

**Links to documentation supporting these rule changes:**

https://github.com/microsoft/vscode-test/blob/master/sample/.gitignore


